### PR TITLE
wait at least 60 seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ properties.json
 
 # Jetbrains IDE
 .idea
+
+secrets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 1.9.2
+  * Force backoff to be at least 60 seconds 
+
+# 1.9.1
+  * Fork to airbytehq
+  * Add backoff logic for rate limiting
+
 # 1.9.0
   * Adds `issue_events` stream [#92](https://github.com/singer-io/tap-github/pull/92)
   * Makes `project_cards` stream a child of `project_columns`[#89](https://github.com/singer-io/tap-github/pull/89)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-github',
-      version='1.9.1',
+      version='1.9.2',
       description='Singer.io tap for extracting data from the GitHub API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_github/__init__.py
+++ b/tap_github/__init__.py
@@ -111,7 +111,10 @@ def authed_get(source, url, headers={}):
             remaining = resp.headers.get('X-RateLimit-Remaining')
             time_to_reset = resp.headers.get('X-RateLimit-Reset', time.time() + 60)
             if remaining is not None and remaining == '0':
-                time.sleep(float(time_to_reset) - time.time())
+                time_to_wait = max(float(time_to_reset) - time.time(), 60) # wait at least 60 seconds
+                reset_time = resp.headers.get('X-RateLimit-Reset', "not set")
+                logger.info(f"Rate limit exceeded. X-RateLimit-Reset header in response is {reset_time}. Waiting {time_to_wait} seconds")
+                time.sleep(time_to_wait)
                 continue  # next attempt
 
             # Handle github's possible failures as retries


### PR DESCRIPTION
We've seen exceptions that indicate we are attempting to wait a negative amount of time when we exceed rate limits. This indicates that the `X-RateLimit-Reset` header is at a point in the past. I have been unable to reproduce this. But this PR changes the time to wait so we wait at least 60 seconds. It also adds more logging. 